### PR TITLE
Added a way to create a custom topic/broker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: scala
+
+scala:
+   - 2.10.4
+   - 2.11.7
+
+script:
+   - sbt ++$TRAVIS_SCALA_VERSION test

--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,10 @@ lazy val publishSettings = Seq(
       </developers>
 )
 
+parallelExecution in Test := false
+fork in run := false
+javaOptions += "-Xmx1G"
+
 lazy val releaseSettings = Seq(
   releaseVersionBump := Version.Bump.Minor,
   releaseCrossBuild := true

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val commonSettings = Seq(
   parallelExecution in Test := false,
   libraryDependencies ++= Seq(
     "org.scalatest" %% "scalatest" % "2.2.5",
-    "org.apache.kafka" %% "kafka" % "0.9.0.0",
+    "org.apache.kafka" %% "kafka" % "0.9.0.1",
     "org.apache.zookeeper" % "zookeeper" % "3.4.7",
     "org.apache.avro" % "avro" % "1.7.7",
 
@@ -36,9 +36,6 @@ lazy val publishSettings = Seq(
       </developers>
 )
 
-parallelExecution in Test := false
-fork in run := false
-javaOptions += "-Xmx1G"
 
 lazy val releaseSettings = Seq(
   releaseVersionBump := Version.Bump.Minor,

--- a/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -40,14 +40,17 @@ object EmbeddedKafka extends EmbeddedKafkaSupport {
   def start()(implicit config: EmbeddedKafkaConfig) = {
     factory = Option(startZooKeeper(config.zooKeeperPort))
     broker = Option(startKafka(config))
+    println(s"STARTED BOTH ZK:${config.zooKeeperPort} KAFKA:${config.kafkaPort}=======================================================================================================")
   }
 
   def startZooKeeper(zkLogsDir: Directory)(implicit config: EmbeddedKafkaConfig): Unit = {
     factory = Option(startZooKeeper(config.zooKeeperPort, zkLogsDir))
+    println(s"STARTED ZK ${config.zooKeeperPort}=======================================================================================================")
   }
 
   def startKafka(kafkaLogDir: Directory)(implicit config: EmbeddedKafkaConfig): Unit = {
     broker = Option(startKafka(config, kafkaLogDir))
+    println(s"STARTED KAFKA ${config.kafkaPort}=======================================================================================================")
   }
 
   /**
@@ -56,15 +59,18 @@ object EmbeddedKafka extends EmbeddedKafkaSupport {
   def stop(): Unit = {
     stopKafka()
     stopZooKeeper()
+    println("STOPPED BOTH=======================================================================================================")
   }
 
   def stopZooKeeper(): Unit = {
     factory.foreach(_.shutdown())
+    println("STOPPED ZK=======================================================================================================")
     factory = None
   }
 
   def stopKafka(): Unit = {
     broker.foreach(_.shutdown)
+    println("STOPPED KAFKA=======================================================================================================")
     broker = None
   }
 
@@ -217,6 +223,7 @@ sealed trait EmbeddedKafkaSupport {
     val factory = ServerCnxnFactory.createFactory
     factory.configure(new InetSocketAddress("localhost", zooKeeperPort), 1024)
     factory.startup(zkServer)
+    println("STARTED ZK=======================================================================================================")
     factory
   }
 
@@ -227,6 +234,7 @@ sealed trait EmbeddedKafkaSupport {
     if (enableLogCompaction) {
       properties.setProperty("log.cleaner.enable", "true")
       properties.setProperty("log.cleaner.min.cleanable.ratio", "0.1")
+      properties.setProperty("log.cleaner.dedupe.buffer.size","2000000")
     }
     properties.setProperty("zookeeper.connect", zkAddress)
     properties.setProperty("broker.id", "0")
@@ -238,6 +246,7 @@ sealed trait EmbeddedKafkaSupport {
 
     val broker = new KafkaServer(new KafkaConfig(properties))
     broker.startup()
+    println("STARTED KAFKA=======================================================================================================")
     broker
   }
   

--- a/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -227,7 +227,7 @@ sealed trait EmbeddedKafkaSupport {
     factory
   }
 
-  def startKafka(config: EmbeddedKafkaConfig, kafkaLogDir: Directory = Directory.makeTemp("kafka"), enableLogCompaction: Boolean = true): KafkaServer = {
+  def startKafka(config: EmbeddedKafkaConfig, kafkaLogDir: Directory = Directory.makeTemp("kafka"), enableLogCompaction: Boolean = false): KafkaServer = {
     val zkAddress = s"localhost:${config.zooKeeperPort}"
     
     val properties: Properties = new Properties

--- a/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -40,17 +40,14 @@ object EmbeddedKafka extends EmbeddedKafkaSupport {
   def start()(implicit config: EmbeddedKafkaConfig) = {
     factory = Option(startZooKeeper(config.zooKeeperPort))
     broker = Option(startKafka(config))
-    println(s"STARTED BOTH ZK:${config.zooKeeperPort} KAFKA:${config.kafkaPort}=======================================================================================================")
   }
 
   def startZooKeeper(zkLogsDir: Directory)(implicit config: EmbeddedKafkaConfig): Unit = {
     factory = Option(startZooKeeper(config.zooKeeperPort, zkLogsDir))
-    println(s"STARTED ZK ${config.zooKeeperPort}=======================================================================================================")
   }
 
   def startKafka(kafkaLogDir: Directory)(implicit config: EmbeddedKafkaConfig): Unit = {
     broker = Option(startKafka(config, kafkaLogDir))
-    println(s"STARTED KAFKA ${config.kafkaPort}=======================================================================================================")
   }
 
   /**
@@ -59,18 +56,15 @@ object EmbeddedKafka extends EmbeddedKafkaSupport {
   def stop(): Unit = {
     stopKafka()
     stopZooKeeper()
-    println("STOPPED BOTH=======================================================================================================")
   }
 
   def stopZooKeeper(): Unit = {
     factory.foreach(_.shutdown())
-    println("STOPPED ZK=======================================================================================================")
     factory = None
   }
 
   def stopKafka(): Unit = {
     broker.foreach(_.shutdown)
-    println("STOPPED KAFKA=======================================================================================================")
     broker = None
   }
 
@@ -223,19 +217,14 @@ sealed trait EmbeddedKafkaSupport {
     val factory = ServerCnxnFactory.createFactory
     factory.configure(new InetSocketAddress("localhost", zooKeeperPort), 1024)
     factory.startup(zkServer)
-    println("STARTED ZK=======================================================================================================")
     factory
   }
 
-  def startKafka(config: EmbeddedKafkaConfig, kafkaLogDir: Directory = Directory.makeTemp("kafka"), enableLogCompaction: Boolean = false): KafkaServer = {
+  def startKafka(config: EmbeddedKafkaConfig, kafkaLogDir: Directory = Directory.makeTemp("kafka"), customBrokerProperties: Map[String,String] = Map()): KafkaServer = {
     val zkAddress = s"localhost:${config.zooKeeperPort}"
     
     val properties: Properties = new Properties
-    if (enableLogCompaction) {
-      properties.setProperty("log.cleaner.enable", "true")
-      properties.setProperty("log.cleaner.min.cleanable.ratio", "0.1")
-      properties.setProperty("log.cleaner.dedupe.buffer.size","2000000")
-    }
+    customBrokerProperties.foreach(x => properties.setProperty(x._1,x._2))
     properties.setProperty("zookeeper.connect", zkAddress)
     properties.setProperty("broker.id", "0")
     properties.setProperty("host.name", "localhost")
@@ -246,7 +235,6 @@ sealed trait EmbeddedKafkaSupport {
 
     val broker = new KafkaServer(new KafkaConfig(properties))
     broker.startup()
-    println("STARTED KAFKA=======================================================================================================")
     broker
   }
   

--- a/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -220,11 +220,11 @@ sealed trait EmbeddedKafkaSupport {
     factory
   }
 
-  def startKafka(config: EmbeddedKafkaConfig, kafkaLogDir: Directory = Directory.makeTemp("kafka"), customBrokerProperties: Map[String,String] = Map()): KafkaServer = {
+  def startKafka(config: EmbeddedKafkaConfig, kafkaLogDir: Directory = Directory.makeTemp("kafka")): KafkaServer = {
     val zkAddress = s"localhost:${config.zooKeeperPort}"
     
     val properties: Properties = new Properties
-    customBrokerProperties.foreach(x => properties.setProperty(x._1,x._2))
+    config.customBrokerProperties.foreach(x => properties.setProperty(x._1,x._2))
     properties.setProperty("zookeeper.connect", zkAddress)
     properties.setProperty("broker.id", "0")
     properties.setProperty("host.name", "localhost")

--- a/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
+++ b/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
@@ -1,6 +1,6 @@
 package net.manub.embeddedkafka
 
-case class EmbeddedKafkaConfig(kafkaPort: Int = 6001, zooKeeperPort: Int = 6000)
+case class EmbeddedKafkaConfig(kafkaPort: Int = 6001, zooKeeperPort: Int = 6000, customBrokerProperties: Map[String,String] = Map())
 
 object EmbeddedKafkaConfig {
   implicit val defaultConfig = EmbeddedKafkaConfig()

--- a/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaObjectSpec.scala
+++ b/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaObjectSpec.scala
@@ -16,7 +16,7 @@ class EmbeddedKafkaObjectSpec extends EmbeddedKafkaSpecSupport {
         zookeeperIsNotAvailable()
       }
 
-      "start and stop Kafka and Zookeeper on different specified ports using an implicit configuration" in {
+    "start and stop Kafka and Zookeeper on different specified ports using an implicit configuration" in {
         implicit val config = EmbeddedKafkaConfig(kafkaPort = 12345, zooKeeperPort = 54321)
         EmbeddedKafka.start()
 
@@ -25,8 +25,9 @@ class EmbeddedKafkaObjectSpec extends EmbeddedKafkaSpecSupport {
 
         EmbeddedKafka.stop()
       }
+    
     }
-
+    
     "invoking the isRunnning method" should {
       "return whether both Kafka and Zookeeper are running" in {
         EmbeddedKafka.start()

--- a/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaSpec.scala
+++ b/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaSpec.scala
@@ -3,13 +3,13 @@ package net.manub.embeddedkafka
 import java.util.Properties
 import java.util.concurrent.TimeoutException
 
-import kafka.consumer.{Consumer, ConsumerConfig, Whitelist}
+import kafka.consumer.{ Consumer, ConsumerConfig, Whitelist }
 import kafka.serializer.StringDecoder
-import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
-import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
+import org.apache.kafka.clients.producer.{ KafkaProducer, ProducerConfig, ProducerRecord }
+import org.apache.kafka.common.serialization.{ ByteArraySerializer, StringSerializer }
 import kafka.admin.AdminUtils
 import org.scalatest.exceptions.TestFailedException
-import org.scalatest.time.{Milliseconds, Seconds, Span}
+import org.scalatest.time.{ Milliseconds, Seconds, Span }
 
 import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -108,29 +108,27 @@ class EmbeddedKafkaSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
         consumer.shutdown()
       }
     }
-    
-    
-    "the createCustomTopic method" should {
-    "create a topic with custom configuration" in {
-      implicit val config = EmbeddedKafkaConfig()
-      val topic = "test_topic"
-      
-      withRunningKafka { 
-        val properties: Properties = new Properties
-        properties.put("cleanup.policy", "compact")
-    
-        createCustomTopic(topic,properties)
-         
-        AdminUtils.topicExists(ZkUtils(s"localhost:${config.zooKeeperPort}", 10000, 10000, false), topic) shouldBe true
-      
-      }
-     }
-    }
-    
 
     "throw a KafkaUnavailableException when Kafka is unavailable when trying to publish" in {
       a[KafkaUnavailableException] shouldBe thrownBy {
         publishStringMessageToKafka("non_existing_topic", "a message")
+      }
+    }
+  }
+
+  "the createCustomTopic method" should {
+    "creates a topic with custom configuration" in {
+      implicit val config = EmbeddedKafkaConfig()
+      val topic = "test_custom_topic"
+
+      withRunningKafka {
+        val properties: Properties = new Properties
+        properties.put("cleanup.policy", "compact")
+
+        createCustomTopic(topic, properties)
+
+        AdminUtils.topicExists(ZkUtils(s"localhost:${config.zooKeeperPort}", 10000, 10000, false), topic) shouldBe true
+
       }
     }
   }
@@ -144,8 +142,7 @@ class EmbeddedKafkaSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
         val producer = new KafkaProducer[String, String](Map(
           ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:6001",
           ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG -> classOf[StringSerializer].getName,
-          ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> classOf[StringSerializer].getName
-        ))
+          ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> classOf[StringSerializer].getName))
 
         whenReady(producer.send(new ProducerRecord[String, String](topic, message))) { _ =>
           consumeFirstStringMessageFrom(topic) shouldBe message
@@ -163,8 +160,7 @@ class EmbeddedKafkaSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
         val producer = new KafkaProducer[String, String](Map(
           ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:6001",
           ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG -> classOf[StringSerializer].getName,
-          ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> classOf[StringSerializer].getName
-        ))
+          ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG -> classOf[StringSerializer].getName))
 
         import Codecs._
         whenReady(producer.send(new ProducerRecord[String, String](topic, message))) { _ =>
@@ -185,8 +181,7 @@ class EmbeddedKafkaSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
         implicit val testAvroClassDecoder = specificAvroDecoder[TestAvroClass](TestAvroClass.SCHEMA$)
 
         val producer = new KafkaProducer[String, TestAvroClass](Map(
-          ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:6001"
-        ), new StringSerializer, specificAvroSerializer[TestAvroClass])
+          ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:6001"), new StringSerializer, specificAvroSerializer[TestAvroClass])
 
         whenReady(producer.send(new ProducerRecord(topic, message))) { _ =>
           consumeFirstMessageFrom[TestAvroClass](topic) shouldBe message

--- a/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaSpec.scala
+++ b/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaSpec.scala
@@ -118,7 +118,7 @@ class EmbeddedKafkaSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
 
   "the createCustomTopic method" should {
     "creates a topic with custom configuration" in {
-      implicit val config = EmbeddedKafkaConfig()
+      implicit val config = EmbeddedKafkaConfig(customBrokerProperties=Map("log.cleaner.dedupe.buffer.size"->"2000000"))
       val topic = "test_custom_topic"
 
       withRunningKafka {

--- a/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaSpec.scala
+++ b/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaSpec.scala
@@ -7,6 +7,7 @@ import kafka.consumer.{Consumer, ConsumerConfig, Whitelist}
 import kafka.serializer.StringDecoder
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
+import kafka.admin.AdminUtils
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.time.{Milliseconds, Seconds, Span}
 
@@ -14,6 +15,7 @@ import scala.collection.JavaConversions._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.language.postfixOps
+import kafka.utils.ZkUtils
 
 class EmbeddedKafkaSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
 
@@ -106,6 +108,25 @@ class EmbeddedKafkaSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
         consumer.shutdown()
       }
     }
+    
+    
+    "the createCustomTopic method" should {
+    "create a topic with custom configuration" in {
+      implicit val config = EmbeddedKafkaConfig()
+      val topic = "test_topic"
+      
+      withRunningKafka { 
+        val properties: Properties = new Properties
+        properties.put("cleanup.policy", "compact")
+    
+        createCustomTopic(topic,properties)
+         
+        AdminUtils.topicExists(ZkUtils(s"localhost:${config.zooKeeperPort}", 10000, 10000, false), topic) shouldBe true
+      
+      }
+     }
+    }
+    
 
     "throw a KafkaUnavailableException when Kafka is unavailable when trying to publish" in {
       a[KafkaUnavailableException] shouldBe thrownBy {

--- a/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaSpecSupport.scala
+++ b/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaSpecSupport.scala
@@ -17,22 +17,22 @@ abstract class EmbeddedKafkaSpecSupport extends TestKit(ActorSystem("embedded-ka
 
   def kafkaIsAvailable(kafkaPort: Int = 6001): Unit = {
     system.actorOf(TcpClient.props(new InetSocketAddress("localhost", kafkaPort), testActor))
-    expectMsg(1 second, ConnectionSuccessful)
+    expectMsg(ConnectionSuccessful)
   }
 
   def zookeeperIsAvailable(zookeeperPort: Int = 6000): Unit = {
     system.actorOf(TcpClient.props(new InetSocketAddress("localhost", zookeeperPort), testActor))
-    expectMsg(1 second, ConnectionSuccessful)
+    expectMsg(ConnectionSuccessful)
   }
 
   def kafkaIsNotAvailable(): Unit = {
     system.actorOf(TcpClient.props(new InetSocketAddress("localhost", 6001), testActor))
-    expectMsg(1 second, ConnectionFailed)
+    expectMsg(ConnectionFailed)
   }
 
   def zookeeperIsNotAvailable(): Unit = {
     system.actorOf(TcpClient.props(new InetSocketAddress("localhost", 6000), testActor))
-    expectMsg(1 second, ConnectionFailed)
+    expectMsg(ConnectionFailed)
   }
 
 }


### PR DESCRIPTION
I have added a method to create a topic with custom configuration, and also an additional Map in the implicit broker config to be able to customise the broker if needed. 

https://travis-ci.org/lucapertile/scalatest-embedded-kafka/builds/130060010