### PR TITLE
Added a way to create topics and brokers by passing a custom configuration

### DIFF
--- a/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -77,6 +77,10 @@ sealed trait EmbeddedKafkaSupport {
   val executorService = Executors.newFixedThreadPool(2)
   implicit val executionContext = ExecutionContext.fromExecutorService(executorService)
 
+  val zkSessionTimeoutMs  = 10000
+  val zkConnectionTimeoutMs = 10000
+  val zkSecurityEnabled = false
+
   /**
     * Starts a ZooKeeper instance and a Kafka broker, then executes the body passed as a parameter.
     *
@@ -244,10 +248,6 @@ sealed trait EmbeddedKafkaSupport {
   }
 
   def createCustomTopic(topic: String, topicConfig: Properties)(implicit config: EmbeddedKafkaConfig): Unit = {
-    val zkSessionTimeoutMs  = 10000
-    val zkConnectionTimeoutMs = 10000
-    val zkSecurityEnabled = false
-
     AdminUtils.createTopic(ZkUtils(s"localhost:${config.zooKeeperPort}", zkSessionTimeoutMs, zkConnectionTimeoutMs, zkSecurityEnabled), topic, 1, 1, topicConfig)
   }
 }

--- a/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
+++ b/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
@@ -1,6 +1,6 @@
 package net.manub.embeddedkafka
 
-case class EmbeddedKafkaConfig(kafkaPort: Int = 6001, zooKeeperPort: Int = 6000)
+case class EmbeddedKafkaConfig(kafkaPort: Int = 6001, zooKeeperPort: Int = 6000, customBrokerProperties: Map[String, String] = Map.empty)
 
 object EmbeddedKafkaConfig {
   implicit val defaultConfig = EmbeddedKafkaConfig()


### PR DESCRIPTION
Cleaned up the formatting noise and implemented the suggested changes. This PR adds support for custom topic and broker creation by enabling clients to pass a custom config when they create a broker or a topic.