### PR TITLE
remove unnnecessary compile dependency and unused class

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,14 +9,15 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq("2.10.6", "2.11.8"),
   homepage := Some(url("https://github.com/manub/scalatest-embedded-kafka")),
   parallelExecution in Test := false,
-  libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % "2.2.5",
+  libraryDependencies <++= (scalaVersion) { scalaVersion => Seq(
+    "org.scala-lang" % "scala-reflect" % scalaVersion,
     "org.apache.kafka" %% "kafka" % "0.10.0.1" exclude(slf4jLog4jOrg, slf4jLog4jArtifact),
     "org.apache.zookeeper" % "zookeeper" % "3.4.7" exclude(slf4jLog4jOrg, slf4jLog4jArtifact),
     "org.apache.avro" % "avro" % "1.7.7" exclude(slf4jLog4jOrg, slf4jLog4jArtifact),
     "com.typesafe.akka" %% "akka-actor" % "2.3.14" % Test,
-    "com.typesafe.akka" %% "akka-testkit" % "2.3.14" % Test
-  )
+    "com.typesafe.akka" %% "akka-testkit" % "2.3.14" % Test,
+    "org.scalatest" %% "scalatest" % "2.2.5" % Test
+  ) }
 )
 
 lazy val publishSettings = Seq(

--- a/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -12,7 +12,6 @@ import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, Produce
 import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.serialization.{Deserializer, Serializer, StringDeserializer, StringSerializer}
 import org.apache.zookeeper.server.{ServerCnxnFactory, ZooKeeperServer}
-import org.scalatest.Suite
 
 import scala.collection.JavaConversions.mapAsJavaMap
 import scala.concurrent.duration._
@@ -21,9 +20,7 @@ import scala.language.{higherKinds, postfixOps}
 import scala.reflect.io.Directory
 import scala.util.Try
 
-trait EmbeddedKafka extends EmbeddedKafkaSupport {
-  this: Suite =>
-}
+trait EmbeddedKafka extends EmbeddedKafkaSupport
 
 object EmbeddedKafka extends EmbeddedKafkaSupport {
 

--- a/src/main/scala/net/manub/embeddedkafka/exceptions.scala
+++ b/src/main/scala/net/manub/embeddedkafka/exceptions.scala
@@ -4,5 +4,3 @@ class KafkaUnavailableException(msg: String, cause: Throwable) extends RuntimeEx
   def this(msg: String) = this(msg, null)
   def this(cause: Throwable) = this(null, cause)
 }
-
-class KafkaSpecException(msg: String) extends RuntimeException(msg)


### PR DESCRIPTION
i think this project has a nice implementation of in-memory kafka and zookeeper, which can be useful no matter what test framework one uses. so i removed the scalatest compile time dependency (it didnt really seem to add anything anyhow).

in-house we renamed this artifact to embedded-kafka to reflect the fact that it can be used with any test framework...