### PR TITLE
fix OutOfMemory issue by making the log cleaner dedupe buffer much smaller

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -311,6 +311,10 @@ sealed trait EmbeddedKafkaSupport {
     properties.setProperty("port", config.kafkaPort.toString)
     properties.setProperty("log.dir", kafkaLogDir.toAbsolute.path)
     properties.setProperty("log.flush.interval.messages", 1.toString)
+
+    // The total memory used for log deduplication across all cleaner threads, keep it small to not exhaust suite memory
+    properties.setProperty("log.cleaner.dedupe.buffer.size", "1048577")
+
     config.customBrokerProperties.foreach {
       case (key, value) => properties.setProperty(key, value)
     }


### PR DESCRIPTION
Similar issue in KAFKA

Reference 1: https://issues.apache.org/jira/browse/KAFKA-1881
Reference 2: https://reviews.apache.org/r/31447/diff/1/

Ref #57 