### PR TITLE
Allow consumeFirstStringMessageFrom to be called multiple times

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
@@ -2,7 +2,8 @@ package net.manub.embeddedkafka
 
 case class EmbeddedKafkaConfig(kafkaPort: Int = 6001,
                                zooKeeperPort: Int = 6000,
-                               customBrokerProperties: Map[String, String] = Map.empty)
+                               customBrokerProperties: Map[String, String] = Map.empty,
+                               autoCommit: Boolean = false)
 
 object EmbeddedKafkaConfig {
   implicit val defaultConfig = EmbeddedKafkaConfig()


### PR DESCRIPTION
In older versions of scalatest-embedded-kafka you were able to call
consumeFirstStringMessageFrom multiple times, with each invocation
causing the next message in a topic to be consumed. In the latest
version this is no longer the case: the first invocation works fine, but
subsequent invocations would result in exceptions as the first
invocation would cause *all* messages to be committed even though only
the first one is returned. We fix this by disabling auto-commit and
simply committing only the message that consumeFirstStringMessageFrom
returns.