### PR TITLE
Increase poll() timeout to 15s

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -250,7 +250,11 @@ sealed trait EmbeddedKafkaSupport {
     val message = Try {
       consumer.subscribe(List(topic))
       consumer.partitionsFor(topic) // as poll doesn't honour the timeout, forcing the consumer to fail here.
-      val records = consumer.poll(5000)
+
+      // poll() occasionally times out right at 10s when consuming a large
+      // number of messages. Extending the timeout above that will prevent
+      // this from happening.
+      val records = consumer.poll(15000)
       if (records.isEmpty) {
         throw new TimeoutException(
           "Unable to retrieve a message from Kafka in 5000ms")

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaMethodsSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaMethodsSpec.scala
@@ -127,8 +127,9 @@ class EmbeddedKafkaMethodsSpec extends EmbeddedKafkaSpecSupport with EmbeddedKaf
     }
 
     "consume only a single message when multiple messages have been published to a topic" in {
-      val messages = Set("message 1", "message 2", "message 3")
       val topic = "consume_test_topic"
+      val numMessages = 300
+      val messages = (1 to numMessages).map("Message " + _)
 
       val producer = new KafkaProducer[String, String](Map(
         ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:6001",
@@ -142,11 +143,11 @@ class EmbeddedKafkaMethodsSpec extends EmbeddedKafkaSpecSupport with EmbeddedKaf
 
       producer.flush()
 
-      val consumedMessages = for (i <- 1 to messages.size) yield {
+      val consumedMessages = for (i <- 1 to numMessages) yield {
         consumeFirstStringMessageFrom(topic)
       }
 
-      consumedMessages.toSet shouldEqual messages
+      consumedMessages shouldEqual messages
 
       producer.close()
     }


### PR DESCRIPTION
`poll()` occasionally times out right at 10s when consuming a large number of messages. This seems to happen when consuming <300 messages one by one using `consumeFirstMessageFrom()`. This PR extends the timeout to 15s to circumvent this issue, and also updates one of the unit tests to trigger this problem.

The number of messages consumed successfully before the (<10s) timeout hits seems to vary. Sometimes it's after 5 messages, and sometimes after 200.

Obviously this is a band-aid for an underlying problem. I wonder if the consumer gets stuck somehow, causing the `session.timeout.ms` timeout to trigger which gets it unstuck. Having a >10 `poll()` timeout would give it enough time to recover.

I'm not sure if this is a problem in the Kafka Consumer or scalatest-embedded-kafka, although consuming 300 messages in another project in a single poll seems to work fine. Unfortunately, I don't have enough in-depth knowledge of (Embedded) Kafka to diagnose and fix the root cause in a timely manner.