### PR TITLE
Custom configuration for consumer and producer

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,30 @@ class MySpec extends WordSpec with EmbeddedKafka {
 
 }
 ```
+
+The same implicit `EmbeddedKafkaConfig` is used to define custom consumer or producer properties
+
+```scala
+class MySpec extends WordSpec with EmbeddedKafka {
+
+"runs with custom producer and consumer properties" should {
+    val customBrokerConfig = Map("replica.fetch.max.bytes" -> "2000000",
+        "message.max.bytes" -> "2000000")
+        
+    val customProducerConfig = Map("max.request.size" -> "2000000")
+    val customConsumerConfig = Map("max.partition.fetch.bytes" -> "2000000")
+
+    implicit val customKafkaConfig = EmbeddedKafkaConfig(
+        customBrokerProperties = customBrokerConfig,
+        customProducerProperties = customProducerConfig,
+        customConsumerProperties = customConsumerConfig)
+
+    withRunningKafka {
+        // now a kafka broker is listening on port 12345
+    }
+
+}
+```
         
 This works for both `withRunningKafka` and `EmbeddedKafka.start()`
 

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -217,6 +217,7 @@ sealed trait EmbeddedKafkaSupport {
     props.put("bootstrap.servers", s"localhost:${config.kafkaPort}")
     props.put("auto.offset.reset", "earliest")
     props.put("enable.auto.commit", "false")
+    props.putAll(config.customConsumerProperties)
     props
   }
 

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -209,7 +209,7 @@ sealed trait EmbeddedKafkaSupport {
     ProducerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:${config.kafkaPort}",
     ProducerConfig.MAX_BLOCK_MS_CONFIG -> 10000.toString,
     ProducerConfig.RETRY_BACKOFF_MS_CONFIG -> 1000.toString
-  )
+  ) ++ config.customProducerProperties
 
   private def baseConsumerConfig(implicit config: EmbeddedKafkaConfig) : Properties = {
     val props = new Properties()

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
@@ -3,7 +3,8 @@ package net.manub.embeddedkafka
 case class EmbeddedKafkaConfig(kafkaPort: Int = 6001,
                                zooKeeperPort: Int = 6000,
                                customBrokerProperties: Map[String, String] = Map.empty,
-                               customProducerProperties: Map[String, String] = Map.empty)
+                               customProducerProperties: Map[String, String] = Map.empty,
+                               customConsumerProperties: Map[String, String] = Map.empty)
 
 object EmbeddedKafkaConfig {
   implicit val defaultConfig = EmbeddedKafkaConfig()

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
@@ -2,7 +2,8 @@ package net.manub.embeddedkafka
 
 case class EmbeddedKafkaConfig(kafkaPort: Int = 6001,
                                zooKeeperPort: Int = 6000,
-                               customBrokerProperties: Map[String, String] = Map.empty)
+                               customBrokerProperties: Map[String, String] = Map.empty,
+                               customProducerProperties: Map[String, String] = Map.empty)
 
 object EmbeddedKafkaConfig {
   implicit val defaultConfig = EmbeddedKafkaConfig()

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaCustomConfigSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaCustomConfigSpec.scala
@@ -3,24 +3,24 @@ package net.manub.embeddedkafka
 import scala.language.postfixOps
 
 class EmbeddedKafkaCustomConfigSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
-  val TWO_MEGABYTES = 2097152
-  val THREE_MEGABYTES = 3145728
+  val TwoMegabytes = 2097152
+  val ThreeMegabytes = 3145728
 
   "the custom config" should {
-    "should allow pass additional producer parameters" in {
+    "allow pass additional producer parameters" in {
       val customBrokerConfig = Map(
-        "replica.fetch.max.bytes" -> s"$THREE_MEGABYTES",
-        "message.max.bytes" -> s"$THREE_MEGABYTES")
+        "replica.fetch.max.bytes" -> s"$ThreeMegabytes",
+        "message.max.bytes" -> s"$ThreeMegabytes")
 
-      val customProducerConfig = Map("max.request.size" -> s"$THREE_MEGABYTES")
-      val customConsumerConfig = Map("max.partition.fetch.bytes" -> s"$THREE_MEGABYTES")
+      val customProducerConfig = Map("max.request.size" -> s"$ThreeMegabytes")
+      val customConsumerConfig = Map("max.partition.fetch.bytes" -> s"$ThreeMegabytes")
 
       implicit val customKafkaConfig = EmbeddedKafkaConfig(
         customBrokerProperties = customBrokerConfig,
         customProducerProperties = customProducerConfig,
         customConsumerProperties = customConsumerConfig)
 
-      val bigMessage = generateMessageOfLength(TWO_MEGABYTES)
+      val bigMessage = generateMessageOfLength(TwoMegabytes)
       val topic = "big-message-topic"
 
       withRunningKafka {

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaCustomConfigSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaCustomConfigSpec.scala
@@ -1,0 +1,22 @@
+package net.manub.embeddedkafka
+
+import scala.language.postfixOps
+
+class EmbeddedKafkaCustomConfigSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
+
+  "the custom config" should {
+    "should allow pass additional producer parameters" in {
+      val customProducerConfig = Map("" -> "")
+      implicit val customKafkaConfig = EmbeddedKafkaConfig(customProducerProperties = customProducerConfig)
+      val bigMessage = generateMessageOfLength(2000000)
+      val topic = "big-message-topic"
+
+      withRunningKafka {
+        publishStringMessageToKafka(topic, bigMessage)
+        consumeFirstStringMessageFrom(topic) shouldBe bigMessage
+      }
+    }
+  }
+
+  def generateMessageOfLength(length: Int): String = Stream.continually(util.Random.nextPrintableChar) take length mkString
+}

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaCustomConfigSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaCustomConfigSpec.scala
@@ -3,12 +3,24 @@ package net.manub.embeddedkafka
 import scala.language.postfixOps
 
 class EmbeddedKafkaCustomConfigSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
+  val TWO_MEGABYTES = 2097152
+  val THREE_MEGABYTES = 3145728
 
   "the custom config" should {
     "should allow pass additional producer parameters" in {
-      val customProducerConfig = Map("" -> "")
-      implicit val customKafkaConfig = EmbeddedKafkaConfig(customProducerProperties = customProducerConfig)
-      val bigMessage = generateMessageOfLength(2000000)
+      val customBrokerConfig = Map(
+        "replica.fetch.max.bytes" -> s"$THREE_MEGABYTES",
+        "message.max.bytes" -> s"$THREE_MEGABYTES")
+
+      val customProducerConfig = Map("max.request.size" -> s"$THREE_MEGABYTES")
+      val customConsumerConfig = Map("max.partition.fetch.bytes" -> s"$THREE_MEGABYTES")
+
+      implicit val customKafkaConfig = EmbeddedKafkaConfig(
+        customBrokerProperties = customBrokerConfig,
+        customProducerProperties = customProducerConfig,
+        customConsumerProperties = customConsumerConfig)
+
+      val bigMessage = generateMessageOfLength(TWO_MEGABYTES)
       val topic = "big-message-topic"
 
       withRunningKafka {


### PR DESCRIPTION
Hi

We need to test message flow with messages bigger than default 1MB.
I've prepared a pull request with additional custom producer and consumer configurations.
I also created a unit test for it and updated README with code example.
Can you take a look ?
Any comments welcome

In near future, I plan to merge it to 0.8 branch, because we need it on Spark 1.6

Regards