### PR TITLE
Consume messages with multiple topics and custom timeout

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -285,9 +285,9 @@ sealed trait EmbeddedKafkaSupport {
       new StringDeserializer())
 
   /**
-    * Consumes the first message available in a given topic, deserializing it as a String.
+    * Consumes the first message available in a given topic, deserializing it as type [[T]].
     *
-    * Only the messsage that is returned is committed if autoCommit is false.
+    * Only the message that is returned is committed if autoCommit is false.
     * If autoCommit is true then all messages that were polled will be committed.
     *
     * @param topic        the topic to consume a message from
@@ -339,20 +339,20 @@ sealed trait EmbeddedKafkaSupport {
   }
 
   /**
-    * Consumes the first n messages available in a given topic, deserializing it as a String, and returns
+    * Consumes the first n messages available in a given topic, deserializes them as type [[T]], and returns
     * the n messages as a List.
     *
-    * Only the messsages that are returned are committed if autoCommit is false.
+    * Only the messages that are returned are committed if autoCommit is false.
     * If autoCommit is true then all messages that were polled will be committed.
     *
-    * @param topic        the topic to consume a message from
-    * @param number       the number of messagese to consume in a batch
-    * @param autoCommit   if false, only the offset for the consumed message will be commited.
+    * @param topic        the topic to consume messages from
+    * @param number       the number of messages to consume in a batch
+    * @param autoCommit   if false, only the offset for the consumed messages will be commited.
     *                     if true, the offset for the last polled message will be committed instead.
     *                     Defaulted to false.
     * @param config       an implicit [[EmbeddedKafkaConfig]]
     * @param deserializer an implicit [[org.apache.kafka.common.serialization.Deserializer]] for the type [[T]]
-    * @return the first message consumed from the given topic, with a type [[T]]
+    * @return the List of messages consumed from the given topic, each with a type [[T]]
     * @throws TimeoutException          if unable to consume a message within 5 seconds
     * @throws KafkaUnavailableException if unable to connect to Kafka
     */


### PR DESCRIPTION
This simplifies a bit of code, and makes two bigger changes:

1. Implement `consumeNumberMessagesFromTopics`, which reads from multiple topics.

2. Add custom timeout in `consumeNumberMessagesFromTopics`, instead of hard-coding 5 seconds. This also counts the total consume time toward the timeout, rather than timing out if there is a 5 second period of silence. E.g. if a user calls this method with number=12 and timeout=5.seconds, and a producer produces one message every 4 seconds, the method will now throw TimeoutException after 5 seconds. The previous behavior would receive all messages in 60 seconds and not throw an exception, because there was at least one message to consume every 5 seconds.

Since change 2 is an actual behavior change, I can take it out of this PR if backwards compatibility is necessary.

My use case is running a complicated algorithm that publishes many messages to many topics, and I want to confirm that the right thing was published everywhere. I know my producer should be done after no more than 30 seconds. But if it fails, I don't want my test to stall for more than 30 seconds.