### PR TITLE
Make EmbeddedKafkaConfig a trait to allow other implementation

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
@@ -1,11 +1,11 @@
 package net.manub.embeddedkafka
 
 trait EmbeddedKafkaConfig {
-  val kafkaPort: Int
-  val zooKeeperPort: Int
-  val customBrokerProperties: Map[String, String]
-  val customProducerProperties: Map[String, String]
-  val customConsumerProperties: Map[String, String]
+  def kafkaPort: Int
+  def zooKeeperPort: Int
+  def customBrokerProperties: Map[String, String]
+  def customProducerProperties: Map[String, String]
+  def customConsumerProperties: Map[String, String]
 }
 
 case class EmbeddedKafkaConfigImpl(

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafkaConfig.scala
@@ -1,11 +1,30 @@
 package net.manub.embeddedkafka
 
-case class EmbeddedKafkaConfig(kafkaPort: Int = 6001,
-                               zooKeeperPort: Int = 6000,
-                               customBrokerProperties: Map[String, String] = Map.empty,
-                               customProducerProperties: Map[String, String] = Map.empty,
-                               customConsumerProperties: Map[String, String] = Map.empty)
+trait EmbeddedKafkaConfig {
+  val kafkaPort: Int
+  val zooKeeperPort: Int
+  val customBrokerProperties: Map[String, String]
+  val customProducerProperties: Map[String, String]
+  val customConsumerProperties: Map[String, String]
+}
+
+case class EmbeddedKafkaConfigImpl(
+                                    kafkaPort: Int,
+                                    zooKeeperPort: Int,
+                                    customBrokerProperties: Map[String, String],
+                                    customProducerProperties: Map[String, String],
+                                    customConsumerProperties: Map[String, String]
+                                  ) extends EmbeddedKafkaConfig
 
 object EmbeddedKafkaConfig {
-  implicit val defaultConfig = EmbeddedKafkaConfig()
+  implicit val defaultConfig: EmbeddedKafkaConfig = apply()
+
+  def apply(
+             kafkaPort: Int = 6001,
+             zooKeeperPort: Int = 6000,
+             customBrokerProperties: Map[String, String] = Map.empty,
+             customProducerProperties: Map[String, String] = Map.empty,
+             customConsumerProperties: Map[String, String] = Map.empty
+           ) : EmbeddedKafkaConfig =
+    EmbeddedKafkaConfigImpl(kafkaPort, zooKeeperPort, customBrokerProperties, customProducerProperties, customConsumerProperties)
 }

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaWithRunningKafkaOnFoundPortSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaWithRunningKafkaOnFoundPortSpec.scala
@@ -29,7 +29,7 @@ class EmbeddedKafkaWithRunningKafkaOnFoundPortSpec
           // Confirm both actual configs are running on separate non-zero ports, but otherwise equal
           allConfigs.map(_.kafkaPort).distinct should have size 3
           allConfigs.map(_.zooKeeperPort).distinct should have size 3
-          allConfigs.map(_.copy(kafkaPort = 0, zooKeeperPort = 0)).distinct should have size 1
+          allConfigs.map(config => EmbeddedKafkaConfigImpl(kafkaPort = 0, zooKeeperPort = 0, config.customBrokerProperties, config.customProducerProperties, config.customConsumerProperties)).distinct should have size 1
           actualConfig2
         }
         bothKafkaAndZkAreNotAvailable(actualConfig2)


### PR DESCRIPTION
I'm using Kafka and a schema registry to serialize messages.
I've made a trait that allow me to run a Kafka and a schema registry:
```scala
trait EmbeddedKafkaAndSchemaRegistrySupport extends EmbeddedKafka {
  this: Suite =>

  def withRunningKafkaAndSchemaRegistry[T](block: (ConfluentConfig) => T): T = {
    implicit val kafkaConfig: EmbeddedKafkaConfig = new EmbeddedKafkaConfig(zooKeeperPort = getEphemeralPort, kafkaPort = getEphemeralPort)
    EmbeddedKafka.start()
    try {
      val confluentConfig = ConfluentConfig(kafkaConfig, schemaRegistryPort = getEphemeralPort)
      val schemaRegistry = startSchemaRegistry(confluentConfig)
      try {
        block(confluentConfig)
      } finally {
        schemaRegistry.stop()
      }
    } finally {
      EmbeddedKafka.stop()
    }
  }
}

case class ConfluentConfig(embeddedKafkaConfig: EmbeddedKafkaConfig, schemaRegistryPort : Int)
```
ConfluentConfig can't extend EmbeddedKafkaConfig because it's a case class so when using 'withRunningKafkaAndSchemaRegistry' I have to declare the implicit EmbeddedKafkaConfig:
```scala
withRunningKafkaAndSchemaRegistryAndImpressionEventSerializer { implicit config => implicit serializer =>
      implicit val kafkaConfig: EmbeddedKafkaConfig = config.embeddedKafkaConfig
      publishToKafka("topic", impressionEvent)
      ...
}
```

I'd like to make EmbeddedKafkaConfig a trait then make ConfluentConfig implements it to avoid declaring each time the EmbeddedKafkaConfig.
Does it make sense? Maybe there's another solution?
I've tried with implicit conversion but without success.
If that make sense I'll make the modifications then a pull request.