### PR TITLE
Concurrent kafka instances

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -15,7 +15,6 @@ import org.apache.zookeeper.server.{ServerCnxnFactory, ZooKeeperServer}
 import org.scalatest.Suite
 
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutorService, TimeoutException}
@@ -29,9 +28,7 @@ trait EmbeddedKafka extends EmbeddedKafkaSupport {
 
 object EmbeddedKafka extends EmbeddedKafkaSupport {
 
-  private[this] var factory: Option[ServerCnxnFactory] = None
-  private[this] var broker: Option[KafkaServer] = None
-  private[this] val logsDirs = mutable.Buffer.empty[Directory]
+  private[this] var servers: Seq[EmbeddedServer] = Seq.empty
 
   /**
     * Starts a ZooKeeper instance and a Kafka broker in memory, using temporary directories for storing logs.
@@ -39,14 +36,15 @@ object EmbeddedKafka extends EmbeddedKafkaSupport {
     *
     * @param config an implicit [[EmbeddedKafkaConfig]]
     */
-  def start()(implicit config: EmbeddedKafkaConfig): Unit = {
+  def start()(implicit config: EmbeddedKafkaConfig): EmbeddedK = {
     val zkLogsDir = Directory.makeTemp("zookeeper-logs")
     val kafkaLogsDir = Directory.makeTemp("kafka-logs")
 
-    factory = Option(startZooKeeper(config.zooKeeperPort, zkLogsDir))
-    broker = Option(startKafka(config, kafkaLogsDir))
+    val factory = EmbeddedZ(startZooKeeper(config.zooKeeperPort, zkLogsDir), zkLogsDir)
+    val broker = EmbeddedK(Option(factory), startKafka(config, kafkaLogsDir), kafkaLogsDir)
 
-    logsDirs ++= Seq(zkLogsDir, kafkaLogsDir)
+    servers :+= broker
+    broker
   }
 
   /**
@@ -54,56 +52,83 @@ object EmbeddedKafka extends EmbeddedKafkaSupport {
     *
     * @param zkLogsDir the path for the Zookeeper logs
     * @param config    an implicit [[EmbeddedKafkaConfig]]
+    * @return          an [[EmbeddedZ]] server
     */
   def startZooKeeper(zkLogsDir: Directory)(
-      implicit config: EmbeddedKafkaConfig): Unit = {
-    factory = Option(startZooKeeper(config.zooKeeperPort, zkLogsDir))
+    implicit config: EmbeddedKafkaConfig): EmbeddedZ = {
+    val factory = EmbeddedZ(startZooKeeper(config.zooKeeperPort, zkLogsDir), zkLogsDir)
+    servers :+= factory
+    factory
   }
 
   /**
     * Starts a Kafka broker in memory, storing logs in a specific location.
     *
-    * @param kafkaLogDir the path for the Kafka logs
-    * @param config      an implicit [[EmbeddedKafkaConfig]]
+    * @param kafkaLogsDir the path for the Kafka logs
+    * @param config       an implicit [[EmbeddedKafkaConfig]]
+    * @return             an [[EmbeddedK]] server
     */
-  def startKafka(kafkaLogDir: Directory)(
-      implicit config: EmbeddedKafkaConfig): Unit = {
-    broker = Option(startKafka(config, kafkaLogDir))
+  def startKafka(kafkaLogsDir: Directory)(
+    implicit config: EmbeddedKafkaConfig): EmbeddedK = {
+    val broker = EmbeddedK(startKafka(config, kafkaLogsDir), kafkaLogsDir)
+    servers :+= broker
+    broker
   }
 
   /**
-    * Stops the in memory ZooKeeper instance and Kafka broker, and deletes the log directories.
+    * Stops all in memory ZooKeeper instances and Kafka brokers, and deletes the log directories.
     */
   def stop(): Unit = {
-    stopKafka()
-    stopZooKeeper()
-    logsDirs.foreach(_.deleteRecursively())
-    logsDirs.clear()
+    servers.foreach(_.stop(true))
+    servers = Seq.empty
   }
 
   /**
-    * Stops the in memory Zookeeper instance, preserving the logs directory.
+    * Stops a specific [[EmbeddedServer]] instance, and deletes the log directory.
+    *
+    * @param server the [[EmbeddedServer]] to be stopped.
+    */
+  def stop(server: EmbeddedServer): Unit = {
+    server.stop(true)
+    servers = servers.filter(x => x != server)
+  }
+
+  /**
+    * Stops all in memory Zookeeper instances, preserving the logs directories.
     */
   def stopZooKeeper(): Unit = {
-    factory.foreach(_.shutdown())
-    factory = None
+    val factories = servers
+      .filter(_.isInstanceOf[EmbeddedZ])
+      .asInstanceOf[Seq[EmbeddedZ]]
+
+    factories
+      .foreach(_.stop(false))
+
+    servers = servers.filter(!factories.contains(_))
   }
 
   /**
-    * Stops the in memory Kafka instance, preserving the logs directory.
+    * Stops all in memory Kafka instances, preserving the logs directories.
     */
   def stopKafka(): Unit = {
-    broker.foreach { b =>
-      b.shutdown()
-      b.awaitShutdown()
-    }
-    broker = None
+    val brokers = servers
+      .filter(_.isInstanceOf[EmbeddedK])
+      .asInstanceOf[Seq[EmbeddedK]]
+
+    brokers
+      .foreach(_.stop(false))
+
+    servers = servers.filter(!brokers.contains(_))
   }
 
   /**
     * Returns whether the in memory Kafka and Zookeeper are running.
     */
-  def isRunning: Boolean = factory.nonEmpty && broker.nonEmpty
+  def isRunning: Boolean =
+    servers
+      .filter(_.isInstanceOf[EmbeddedK])
+      .asInstanceOf[Seq[EmbeddedK]]
+      .exists(_.factory.isDefined)
 }
 
 sealed trait EmbeddedKafkaSupport {

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedServer.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedServer.scala
@@ -1,0 +1,42 @@
+package net.manub.embeddedkafka
+
+import kafka.server.KafkaServer
+import org.apache.zookeeper.server.ServerCnxnFactory
+
+import scala.reflect.io.Directory
+
+sealed trait EmbeddedServer {
+
+  def stop(clearLogs: Boolean): Unit
+}
+
+case class EmbeddedZ(factory: ServerCnxnFactory,
+                     logsDirs: Directory)(
+                      implicit config: EmbeddedKafkaConfig) extends EmbeddedServer {
+
+  override def stop(clearLogs: Boolean) = {
+    factory.shutdown()
+    if (clearLogs) logsDirs.deleteRecursively()
+  }
+}
+
+case class EmbeddedK(factory: Option[EmbeddedZ],
+                     broker: KafkaServer,
+                     logsDirs: Directory)(
+                      implicit config: EmbeddedKafkaConfig) extends EmbeddedServer {
+
+  override def stop(clearLogs: Boolean) = {
+    broker.shutdown()
+    broker.awaitShutdown()
+
+    factory.foreach(_.stop(clearLogs))
+
+    if (clearLogs) logsDirs.deleteRecursively()
+  }
+}
+
+object EmbeddedK {
+  def apply(broker: KafkaServer, logsDirs: Directory)(
+    implicit config: EmbeddedKafkaConfig): EmbeddedK =
+    EmbeddedK(None, broker, logsDirs)
+}

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedServer.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedServer.scala
@@ -5,26 +5,55 @@ import org.apache.zookeeper.server.ServerCnxnFactory
 
 import scala.reflect.io.Directory
 
+/**
+  * Represents a running server with a method of stopping the instance.
+  */
 sealed trait EmbeddedServer {
 
   def stop(clearLogs: Boolean): Unit
 }
 
+/**
+  * An instance of an embedded Zookeeper server.
+  *
+  * @param factory    the server.
+  * @param logsDirs   the [[Directory]] logs are to be written to.
+  * @param config     the [[EmbeddedKafkaConfig]] used to start the factory.
+  */
 case class EmbeddedZ(factory: ServerCnxnFactory,
                      logsDirs: Directory)(
                       implicit config: EmbeddedKafkaConfig) extends EmbeddedServer {
 
+  /**
+    * Shuts down the factory and then optionally deletes the log directory.
+    *
+    * @param clearLogs  pass `true` to recursively delete the log directory.
+    */
   override def stop(clearLogs: Boolean) = {
     factory.shutdown()
     if (clearLogs) logsDirs.deleteRecursively()
   }
 }
 
+/**
+  * An instance of an embedded Kafka serer.
+  *
+  * @param factory    the optional [[EmbeddedZ]] server which Kafka relies upon.
+  * @param broker     the Kafka server.
+  * @param logsDirs   the [[Directory]] logs are to be written to.
+  * @param config     the [[EmbeddedKafkaConfig]] used to start the broker.
+  */
 case class EmbeddedK(factory: Option[EmbeddedZ],
                      broker: KafkaServer,
                      logsDirs: Directory)(
                       implicit config: EmbeddedKafkaConfig) extends EmbeddedServer {
 
+  /**
+    * Shuts down the broker and the factory it relies upon, if defined.
+    * Optionally deletes the log directory.
+    *
+    * @param clearLogs  pass `true` to recursively delete the log directory.
+    */
   override def stop(clearLogs: Boolean) = {
     broker.shutdown()
     broker.awaitShutdown()

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaObjectSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaObjectSpec.scala
@@ -64,29 +64,16 @@ class EmbeddedKafkaObjectSpec extends EmbeddedKafkaSpecSupport {
         val someOtherBroker = EmbeddedKafka.start()(someOtherConfig)
 
         val topic = "publish_test_topic_1"
-        val someMessage = "hello world!"
         val someOtherMessage = "another message!"
 
         val serializer = new StringSerializer
         val deserializer = new StringDeserializer
 
-        publishToKafka(topic, someMessage)(someConfig, serializer)
+        publishToKafka(topic, "hello world!")(someConfig, serializer)
         publishToKafka(topic, someOtherMessage)(someOtherConfig, serializer)
 
-        // first
-
-        val consumer = kafkaConsumer(someConfig, deserializer, deserializer)
-        consumer.subscribe(List(topic).asJava)
-
-        val records = consumer.poll(consumerPollTimeout)
-        records.count shouldBe 1
-
-        val record = records.iterator().next
-        record.value shouldBe someMessage
-
+        kafkaIsAvailable(someConfig.kafkaPort)
         EmbeddedKafka.stop(someBroker)
-
-        // second
 
         val anotherConsumer = kafkaConsumer(someOtherConfig, deserializer, deserializer)
         anotherConsumer.subscribe(List(topic).asJava)


### PR DESCRIPTION
```
THIS IS A WORK IN PROGRESS
```

Functionally the changes are made. I would like to make some refactorings first and also look into the query raised by @shashidesai.

I'm raising this PR now in the hopes that you can take a look at my approach. If you have any major concerns it would be best to find out sooner!

Closes #101 

TODO:

- [x] @shashidesai's query around `runStreams`
- [x] ~implicit conversion~ extension  method to go from `Seq[EmbeddedServer]` => `Seq[EmbeddedZ]` or `Seq[EmbeddedK]`, replacing the boiler place `isInstanceOf` + `asInstanceOf`
- [x] clean up of new tests for conciseness
- [x] javadoc for `EmbeddedServer.scala`

## Problem

Running tests in parallel which use `EmbeddedKafka` can run into an issue with the log files as `EmbeddedKafka#stop` clears all temporary log directories, which another instance of kafka may still be relying on in another test.

To see this error I changed `logback.xml` line 1 to: `log4j.rootLogger=error,stdout`:

`FATAL [Replica Manager on Broker 0]: Error writing to highwatermark file` ... `java.io.FileNotFoundException` ... `kafka-logsXXXXXXXXX.tmp/replication-offset-checkpoint.tmp (No such file or directory)`

## Testing

_I would like to improve these as there is quite a lot of repetition_

- [start and stop a specific Kafka](https://github.com/tjheslin1/scalatest-embedded-kafka/blob/concurrent-kafka/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaObjectSpec.scala#L38)
- [start and stop multiple Kafka instances on specified ports](https://github.com/tjheslin1/scalatest-embedded-kafka/blob/concurrent-kafka/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaObjectSpec.scala#L59)

## Solution

I have created a model of the running servers, both Kafka and Zookeeper. Starting one of these appends an `EmbeddedServer` to managed list of `servers`.

The following functions have had their signatures modified. Given that they all used to return `Unit`, this results in a non-breaking change to users. On upgrading the returned objects will be ignored and the existing functionality will be preserved.

[EmbeddedKafka#start](https://github.com/tjheslin1/scalatest-embedded-kafka/blob/concurrent-kafka/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala#L39) now returns an `EmbeddedServer`.

[EmbeddedKafka#startZooKeeper](https://github.com/tjheslin1/scalatest-embedded-kafka/blob/concurrent-kafka/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala#L57) now returns an `EmbeddedZ`.

[EmbeddedKafka#startKafka](https://github.com/tjheslin1/scalatest-embedded-kafka/blob/concurrent-kafka/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala#L71) now returns an `EmbeddedK`.

I have added an overload to [EmbeddedKafka#stop](https://github.com/tjheslin1/scalatest-embedded-kafka/blob/concurrent-kafka/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala#L91) which will stop the specific server and remove it from the list of managed servers.