### PR TITLE
Simplify publish producer record method - remove unused topic argument

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -246,14 +246,13 @@ sealed trait EmbeddedKafkaSupport {
   /**
     * Publishes synchronously a message to the running Kafka broker.
     *
-    * @param topic          the topic to which publish the message (it will be auto-created)
     * @param producerRecord the producerRecord of type [[T]] to publish
     * @param config         an implicit [[EmbeddedKafkaConfig]]
     * @param serializer     an implicit [[Serializer]] for the type [[T]]
     * @throws KafkaUnavailableException if unable to connect to Kafka
     */
   @throws(classOf[KafkaUnavailableException])
-  def publishToKafka[T](topic: String, producerRecord: ProducerRecord[String, T])(
+  def publishToKafka[T](producerRecord: ProducerRecord[String, T])(
       implicit config: EmbeddedKafkaConfig,
       serializer: Serializer[T]): Unit =
     publishToKafka(new KafkaProducer(baseProducerConfig.asJava,

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaMethodsSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaMethodsSpec.scala
@@ -68,7 +68,7 @@ class EmbeddedKafkaMethodsSpec
       val headers = new RecordHeaders().add("my_header", headerValue.toCharArray.map(_.toByte))
       val producerRecord = new ProducerRecord[String, String](topic, null, "key", message, headers)
 
-      publishToKafka(topic, producerRecord)
+      publishToKafka(producerRecord)
 
       val consumer = kafkaConsumer
       consumer.subscribe(List(topic).asJava)


### PR DESCRIPTION
I have found that the `topic` argument have never been used in the `publishToKafka(ProducerRecord)` method. This is expected, because the `topic` is available in the `ProducerRecord`.