### PR TITLE
Use Scala Map instead of Java Properties, when possible

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/Consumers.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/Consumers.scala
@@ -1,8 +1,6 @@
 package net.manub.embeddedkafka
 
-import java.util.Properties
-
-import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.common.serialization.Deserializer
 
 /** Utility trait for easily creating Kafka consumers and accessing their consumed messages. */
@@ -51,12 +49,14 @@ trait Consumers {
     */
   def newConsumer[K: Deserializer, V: Deserializer]()(
       implicit config: EmbeddedKafkaConfig): KafkaConsumer[K, V] = {
-    val props = new Properties()
-    props.put("group.id", UUIDs.newUuid().toString)
-    props.put("bootstrap.servers", s"localhost:${config.kafkaPort}")
-    props.put("auto.offset.reset", "earliest")
+    import scala.collection.JavaConverters._
 
-    new KafkaConsumer[K, V](props,
+    val consumerConfig = Map[String, Object](
+      ConsumerConfig.GROUP_ID_CONFIG -> UUIDs.newUuid().toString,
+      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:${config.kafkaPort}",
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> "earliest"
+    )
+    new KafkaConsumer[K, V](consumerConfig.asJava,
                             implicitly[Deserializer[K]],
                             implicitly[Deserializer[V]])
   }

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/Consumers.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/Consumers.scala
@@ -1,6 +1,10 @@
 package net.manub.embeddedkafka
 
-import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
+import org.apache.kafka.clients.consumer.{
+  ConsumerConfig,
+  KafkaConsumer,
+  OffsetResetStrategy
+}
 import org.apache.kafka.common.serialization.Deserializer
 
 /** Utility trait for easily creating Kafka consumers and accessing their consumed messages. */
@@ -54,7 +58,7 @@ trait Consumers {
     val consumerConfig = Map[String, Object](
       ConsumerConfig.GROUP_ID_CONFIG -> UUIDs.newUuid().toString,
       ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:${config.kafkaPort}",
-      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> "earliest"
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> OffsetResetStrategy.EARLIEST.toString.toLowerCase
     )
     new KafkaConsumer[K, V](consumerConfig.asJava,
                             implicitly[Deserializer[K]],

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -11,7 +11,8 @@ import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.clients.consumer.{
   ConsumerConfig,
   KafkaConsumer,
-  OffsetAndMetadata
+  OffsetAndMetadata,
+  OffsetResetStrategy
 }
 import org.apache.kafka.clients.producer.{
   KafkaProducer,
@@ -419,7 +420,7 @@ sealed trait EmbeddedKafkaSupport {
     Map[String, Object](
       ConsumerConfig.GROUP_ID_CONFIG -> "embedded-kafka-spec",
       ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:${config.kafkaPort}",
-      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> "earliest",
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> OffsetResetStrategy.EARLIEST.toString.toLowerCase,
       ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> false.toString
     ) ++ avro.schemaregistry.consumerConfigForSchemaRegistry
       .getOrElse(Map.empty) ++ config.customConsumerProperties

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -8,7 +8,11 @@ import io.confluent.kafka.schemaregistry.RestApp
 import io.confluent.kafka.schemaregistry.avro.AvroCompatibilityLevel
 import kafka.server.{KafkaConfig, KafkaServer}
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
-import org.apache.kafka.clients.consumer.{KafkaConsumer, OffsetAndMetadata}
+import org.apache.kafka.clients.consumer.{
+  ConsumerConfig,
+  KafkaConsumer,
+  OffsetAndMetadata
+}
 import org.apache.kafka.clients.producer.{
   KafkaProducer,
   ProducerConfig,
@@ -398,7 +402,9 @@ sealed trait EmbeddedKafkaSupport {
   def kafkaConsumer[K, T](implicit config: EmbeddedKafkaConfig,
                           keyDeserializer: Deserializer[K],
                           deserializer: Deserializer[T]) =
-    new KafkaConsumer[K, T](baseConsumerConfig, keyDeserializer, deserializer)
+    new KafkaConsumer[K, T](baseConsumerConfig.asJava,
+                            keyDeserializer,
+                            deserializer)
 
   private def baseProducerConfig(implicit config: EmbeddedKafkaConfig) =
     Map[String, Object](
@@ -406,20 +412,16 @@ sealed trait EmbeddedKafkaSupport {
       ProducerConfig.MAX_BLOCK_MS_CONFIG -> 10000.toString,
       ProducerConfig.RETRY_BACKOFF_MS_CONFIG -> 1000.toString
     ) ++ avro.schemaregistry.configForSchemaRegistry
-      .getOrElse(Map.empty[String, Object]) ++ config.customProducerProperties
+      .getOrElse(Map.empty) ++ config.customProducerProperties
 
-  private def baseConsumerConfig(
-      implicit config: EmbeddedKafkaConfig): Properties = {
-    val props = new Properties()
-    props.put("group.id", s"embedded-kafka-spec")
-    props.put("bootstrap.servers", s"localhost:${config.kafkaPort}")
-    props.put("auto.offset.reset", "earliest")
-    props.put("enable.auto.commit", "false")
-    avro.schemaregistry.consumerConfigForSchemaRegistry.foreach(m =>
-      props.putAll(m.asJava))
-    props.putAll(config.customConsumerProperties.asJava)
-    props
-  }
+  private def baseConsumerConfig(implicit config: EmbeddedKafkaConfig) =
+    Map[String, Object](
+      ConsumerConfig.GROUP_ID_CONFIG -> "embedded-kafka-spec",
+      ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG -> s"localhost:${config.kafkaPort}",
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> "earliest",
+      ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> false.toString
+    ) ++ avro.schemaregistry.consumerConfigForSchemaRegistry
+      .getOrElse(Map.empty) ++ config.customConsumerProperties
 
   def consumeFirstStringMessageFrom(topic: String, autoCommit: Boolean = false)(
       implicit config: EmbeddedKafkaConfig): String =
@@ -582,15 +584,14 @@ sealed trait EmbeddedKafkaSupport {
       implicit config: EmbeddedKafkaConfig,
       keyDeserializer: Deserializer[K],
       valueDeserializer: Deserializer[V]): Map[String, List[(K, V)]] = {
-
-    import scala.collection.JavaConverters._
-
-    val props = baseConsumerConfig
-    props.put("enable.auto.commit", autoCommit.toString)
+    val consumerProperties = baseConsumerConfig ++ Map[String, Object](
+      ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG -> autoCommit.toString
+    )
 
     var timeoutNanoTime = System.nanoTime + timeout.toNanos
-    val consumer =
-      new KafkaConsumer[K, V](props, keyDeserializer, valueDeserializer)
+    val consumer = new KafkaConsumer[K, V](consumerProperties.asJava,
+                                           keyDeserializer,
+                                           valueDeserializer)
 
     val messages = Try {
       val messagesBuffers = topics.map(_ -> ListBuffer.empty[(K, V)]).toMap
@@ -692,28 +693,23 @@ sealed trait EmbeddedKafkaSupport {
     val zkAddress = s"localhost:$zooKeeperPort"
     val listener = s"PLAINTEXT://localhost:$kafkaPort"
 
-    val properties = new Properties
-    properties.setProperty("zookeeper.connect", zkAddress)
-    properties.setProperty("broker.id", "0")
-    properties.setProperty("listeners", listener)
-    properties.setProperty("advertised.listeners", listener)
-    properties.setProperty("auto.create.topics.enable", "true")
-    properties.setProperty("log.dir", kafkaLogDir.toAbsolute.path)
-    properties.setProperty("log.flush.interval.messages", 1.toString)
-    properties.setProperty("offsets.topic.replication.factor", 1.toString)
-    properties.setProperty("offsets.topic.num.partitions", 1.toString)
-    properties.setProperty("transaction.state.log.replication.factor",
-                           1.toString)
-    properties.setProperty("transaction.state.log.min.isr", 1.toString)
+    val brokerProperties = Map[String, Object](
+      "zookeeper.connect" -> zkAddress,
+      "broker.id" -> 0.toString,
+      "listeners" -> listener,
+      "advertised.listeners" -> listener,
+      "auto.create.topics.enable" -> true.toString,
+      "log.dir" -> kafkaLogDir.toAbsolute.path,
+      "log.flush.interval.messages" -> 1.toString,
+      "offsets.topic.replication.factor" -> 1.toString,
+      "offsets.topic.num.partitions" -> 1.toString,
+      "transaction.state.log.replication.factor" -> 1.toString,
+      "transaction.state.log.min.isr" -> 1.toString,
+      // The total memory used for log deduplication across all cleaner threads, keep it small to not exhaust suite memory
+      "log.cleaner.dedupe.buffer.size" -> 1048577.toString
+    ) ++ customBrokerProperties
 
-    // The total memory used for log deduplication across all cleaner threads, keep it small to not exhaust suite memory
-    properties.setProperty("log.cleaner.dedupe.buffer.size", "1048577")
-
-    customBrokerProperties.foreach {
-      case (key, value) => properties.setProperty(key, value)
-    }
-
-    val broker = new KafkaServer(new KafkaConfig(properties))
+    val broker = new KafkaServer(new KafkaConfig(brokerProperties.asJava))
     broker.startup()
     broker
   }

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -18,6 +18,7 @@ import org.apache.kafka.clients.producer.{
   ProducerConfig,
   ProducerRecord
 }
+import org.apache.kafka.common.security.auth.SecurityProtocol
 import org.apache.kafka.common.serialization.{
   Deserializer,
   Serializer,
@@ -691,22 +692,22 @@ sealed trait EmbeddedKafkaSupport {
                          customBrokerProperties: Map[String, String],
                          kafkaLogDir: Directory) = {
     val zkAddress = s"localhost:$zooKeeperPort"
-    val listener = s"PLAINTEXT://localhost:$kafkaPort"
+    val listener = s"${SecurityProtocol.PLAINTEXT}://localhost:$kafkaPort"
 
     val brokerProperties = Map[String, Object](
-      "zookeeper.connect" -> zkAddress,
-      "broker.id" -> 0.toString,
-      "listeners" -> listener,
-      "advertised.listeners" -> listener,
-      "auto.create.topics.enable" -> true.toString,
-      "log.dir" -> kafkaLogDir.toAbsolute.path,
-      "log.flush.interval.messages" -> 1.toString,
-      "offsets.topic.replication.factor" -> 1.toString,
-      "offsets.topic.num.partitions" -> 1.toString,
-      "transaction.state.log.replication.factor" -> 1.toString,
-      "transaction.state.log.min.isr" -> 1.toString,
+      KafkaConfig.ZkConnectProp -> zkAddress,
+      KafkaConfig.BrokerIdProp -> 0.toString,
+      KafkaConfig.ListenersProp -> listener,
+      KafkaConfig.AdvertisedListenersProp -> listener,
+      KafkaConfig.AutoCreateTopicsEnableProp -> true.toString,
+      KafkaConfig.LogDirProp -> kafkaLogDir.toAbsolute.path,
+      KafkaConfig.LogFlushIntervalMessagesProp -> 1.toString,
+      KafkaConfig.OffsetsTopicReplicationFactorProp -> 1.toString,
+      KafkaConfig.OffsetsTopicPartitionsProp -> 1.toString,
+      KafkaConfig.TransactionsTopicReplicationFactorProp -> 1.toString,
+      KafkaConfig.TransactionsTopicMinISRProp -> 1.toString,
       // The total memory used for log deduplication across all cleaner threads, keep it small to not exhaust suite memory
-      "log.cleaner.dedupe.buffer.size" -> 1048577.toString
+      KafkaConfig.LogCleanerDedupeBufferSizeProp -> 1048577.toString
     ) ++ customBrokerProperties
 
     val broker = new KafkaServer(new KafkaConfig(brokerProperties.asJava))

--- a/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaCustomConfigSpec.scala
+++ b/embedded-kafka/src/test/scala/net/manub/embeddedkafka/EmbeddedKafkaCustomConfigSpec.scala
@@ -1,5 +1,9 @@
 package net.manub.embeddedkafka
 
+import kafka.server.KafkaConfig
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+
 import scala.language.postfixOps
 
 class EmbeddedKafkaCustomConfigSpec extends EmbeddedKafkaSpecSupport with EmbeddedKafka {
@@ -8,12 +12,15 @@ class EmbeddedKafkaCustomConfigSpec extends EmbeddedKafkaSpecSupport with Embedd
 
   "the custom config" should {
     "allow pass additional producer parameters" in {
-      val customBrokerConfig = Map(
-        "replica.fetch.max.bytes" -> s"$ThreeMegabytes",
-        "message.max.bytes" -> s"$ThreeMegabytes")
+      val customBrokerConfig =
+        Map(KafkaConfig.ReplicaFetchMaxBytesProp -> s"$ThreeMegabytes",
+            KafkaConfig.MessageMaxBytesProp -> s"$ThreeMegabytes")
 
-      val customProducerConfig = Map("max.request.size" -> s"$ThreeMegabytes")
-      val customConsumerConfig = Map("max.partition.fetch.bytes" -> s"$ThreeMegabytes")
+      val customProducerConfig =
+        Map(ProducerConfig.MAX_REQUEST_SIZE_CONFIG -> s"$ThreeMegabytes")
+      val customConsumerConfig =
+        Map(
+          ConsumerConfig.MAX_PARTITION_FETCH_BYTES_CONFIG -> s"$ThreeMegabytes")
 
       implicit val customKafkaConfig = EmbeddedKafkaConfig(
         customBrokerProperties = customBrokerConfig,

--- a/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/TestStreamsConfig.scala
+++ b/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/TestStreamsConfig.scala
@@ -4,7 +4,7 @@ import java.nio.file.Files
 
 import net.manub.embeddedkafka.avro
 import net.manub.embeddedkafka.EmbeddedKafkaConfig
-import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.{ConsumerConfig, OffsetResetStrategy}
 import org.apache.kafka.streams.StreamsConfig
 
 /** Mixin trait for tests allowing to easily create Kafka Stream configurations for tests. */
@@ -30,7 +30,7 @@ trait TestStreamsConfig {
         .createTempDirectory(streamName)
         .toString,
       // force stream consumers to start reading from the beginning so as not to lose messages
-      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> "earliest"
+      ConsumerConfig.AUTO_OFFSET_RESET_CONFIG -> OffsetResetStrategy.EARLIEST.toString.toLowerCase
     )
     val configOverwrittenByExtra = defaultConfig ++
       avro.schemaregistry.consumerConfigForSchemaRegistry


### PR DESCRIPTION
Fix #118.

Java `Properties` are still used when creating Schema Registry instances and topics via `AdminUtils` (#121 will take care of the latter).