### PR TITLE
Make runStreams return value comply with withRunningKafka's

### DIFF
--- a/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreams.scala
+++ b/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreams.scala
@@ -39,10 +39,10 @@ trait EmbeddedKafkaStreams extends EmbeddedKafka with TestStreamsConfig {
     * @param block          the code block that will executed while the streams are active.
     *                       Once the block has been executed the streams will be closed.
     */
-  def runStreams(topicsToCreate: Seq[String],
-                 topology: Topology,
-                 extraConfig: Map[String, AnyRef] = Map.empty)(block: => Any)(
-      implicit config: EmbeddedKafkaConfig): Any =
+  def runStreams[T](topicsToCreate: Seq[String],
+                    topology: Topology,
+                    extraConfig: Map[String, AnyRef] = Map.empty)(block: => T)(
+      implicit config: EmbeddedKafkaConfig): T =
     withRunningKafka {
       topicsToCreate.foreach(topic => createCustomTopic(topic))
       val streamId = UUIDs.newUuid().toString


### PR DESCRIPTION
`=> Any` is not a very good looking return type.