### PR TITLE
Remove log4j and slf4j

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,6 @@ val kafkaVersion = "1.1.0"
 val confluentVersion = "4.1.0"
 val akkaVersion = "2.5.11"
 
-val slf4jLog4jOrg = "org.slf4j"
-val slf4jLog4jArtifact = "slf4j-log4j12"
-
 lazy val confluentMavenRepo = "confluent" at "https://packages.confluent.io/maven/"
 
 lazy val commonSettings = Seq(
@@ -19,6 +16,10 @@ lazy val commonSettings = Seq(
   homepage := Some(url("https://github.com/manub/scalatest-embedded-kafka")),
   parallelExecution in Test := false,
   logBuffered in Test := false,
+  excludeDependencies ++= Seq(
+    ExclusionRule("org.slf4j", "slf4j-log4j12"),
+    ExclusionRule("log4j", "log4j")
+  ),
   fork in Test := true,
   javaOptions += "-Xmx1G",
   scalacOptions += "-deprecation"
@@ -29,10 +30,10 @@ lazy val commonLibrarySettings = libraryDependencies ++= Seq(
   "io.confluent" % "kafka-schema-registry" % confluentVersion,
   "io.confluent" % "kafka-schema-registry" % confluentVersion classifier "tests",
   "org.scalatest" %% "scalatest" % "3.0.5",
-  "org.apache.kafka" %% "kafka" % kafkaVersion exclude(slf4jLog4jOrg, slf4jLog4jArtifact),
+  "org.apache.kafka" %% "kafka" % kafkaVersion,
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % Test,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
-  slf4jLog4jOrg % slf4jLog4jArtifact % "1.7.25" % Test
+  "ch.qos.logback" % "logback-classic" % "1.2.3" % Test
 )
 
 lazy val publishSettings = Seq(
@@ -86,6 +87,6 @@ lazy val kafkaStreams = (project in file("kafka-streams"))
   .settings(commonLibrarySettings)
   .settings(releaseSettings: _*)
   .settings(libraryDependencies ++= Seq(
-    "org.apache.kafka" % "kafka-streams" % kafkaVersion exclude(slf4jLog4jOrg, slf4jLog4jArtifact)
+    "org.apache.kafka" % "kafka-streams" % kafkaVersion
   ))
   .dependsOn(embeddedKafka)

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/ConsumerExtensions.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/ConsumerExtensions.scala
@@ -2,7 +2,6 @@ package net.manub.embeddedkafka
 
 import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.KafkaException
-import org.apache.log4j.Logger
 
 import scala.util.Try
 
@@ -12,8 +11,6 @@ object ConsumerExtensions {
   case class ConsumerRetryConfig(maximumAttempts: Int = 3, poll: Long = 2000)
 
   implicit class ConsumerOps[K, V](val consumer: KafkaConsumer[K, V]) {
-
-    private val logger = Logger.getLogger(getClass)
 
     /** Consume messages from one or many topics and return them as a lazily evaluated Scala Stream.
       * Depending on how many messages are taken from the Scala Stream it will try up to retryConf.maximumAttempts times
@@ -32,10 +29,8 @@ object ConsumerExtensions {
         retryConf: ConsumerRetryConfig = ConsumerRetryConfig()
     ): Stream[T] = {
       val attempts = 1 to retryConf.maximumAttempts
-      attempts.toStream.flatMap { attempt =>
-        val batch: Seq[T] = getNextBatch(retryConf.poll, topics)
-        logger.debug(s"----> Batch $attempt ($topics) | ${batch.mkString("|")}")
-        batch
+      attempts.toStream.flatMap { _ =>
+        getNextBatch[T](retryConf.poll, topics)
       }
     }
 

--- a/embedded-kafka/src/test/resources/log4j.properties
+++ b/embedded-kafka/src/test/resources/log4j.properties
@@ -1,7 +1,0 @@
-log4j.rootLogger=off
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-
-# Pattern to output the caller's file name and line number.
-log4j.appender.stdout.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n

--- a/embedded-kafka/src/test/resources/logback-test.xml
+++ b/embedded-kafka/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="OFF">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreams.scala
+++ b/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreams.scala
@@ -2,7 +2,6 @@ package net.manub.embeddedkafka.streams
 
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig, UUIDs}
 import org.apache.kafka.streams.{KafkaStreams, Topology}
-import org.apache.log4j.Logger
 import org.scalatest.Suite
 
 /** Helper trait for testing Kafka Streams.
@@ -11,8 +10,6 @@ import org.scalatest.Suite
   */
 trait EmbeddedKafkaStreams extends EmbeddedKafka with TestStreamsConfig {
   this: Suite =>
-
-  private val logger = Logger.getLogger(classOf[EmbeddedKafkaStreams])
 
   /** Execute Kafka streams and pass a block of code that can
     * operate while the streams are active.
@@ -34,7 +31,6 @@ trait EmbeddedKafkaStreams extends EmbeddedKafka with TestStreamsConfig {
     withRunningKafka {
       topicsToCreate.foreach(topic => createCustomTopic(topic))
       val streamId = UUIDs.newUuid().toString
-      logger.debug(s"Creating stream with Application ID: [$streamId]")
       val streams =
         new KafkaStreams(topology, streamConfig(streamId, extraConfig))
       streams.start()

--- a/kafka-streams/src/test/resources/log4j.properties
+++ b/kafka-streams/src/test/resources/log4j.properties
@@ -1,7 +1,0 @@
-log4j.rootLogger=off
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-
-# Pattern to output the caller's file name and line number.
-log4j.appender.stdout.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n

--- a/kafka-streams/src/test/resources/logback-test.xml
+++ b/kafka-streams/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="OFF">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Completes the work started in the obsolete `remove_log4j` branch.