### PR TITLE
Fix logging dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,6 @@ val kafkaVersion = "1.1.0"
 val confluentVersion = "4.1.0"
 val akkaVersion = "2.5.11"
 
-val slf4jLog4jOrg = "org.slf4j"
-val slf4jLog4jArtifact = "slf4j-log4j12"
-
 lazy val confluentMavenRepo = "confluent" at "https://packages.confluent.io/maven/"
 
 lazy val commonSettings = Seq(
@@ -29,10 +26,9 @@ lazy val commonLibrarySettings = libraryDependencies ++= Seq(
   "io.confluent" % "kafka-schema-registry" % confluentVersion,
   "io.confluent" % "kafka-schema-registry" % confluentVersion classifier "tests",
   "org.scalatest" %% "scalatest" % "3.0.5",
-  "org.apache.kafka" %% "kafka" % kafkaVersion exclude(slf4jLog4jOrg, slf4jLog4jArtifact),
+  "org.apache.kafka" %% "kafka" % kafkaVersion,
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % Test,
-  "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test,
-  slf4jLog4jOrg % slf4jLog4jArtifact % "1.7.25" % Test
+  "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test
 )
 
 lazy val publishSettings = Seq(
@@ -86,6 +82,6 @@ lazy val kafkaStreams = (project in file("kafka-streams"))
   .settings(commonLibrarySettings)
   .settings(releaseSettings: _*)
   .settings(libraryDependencies ++= Seq(
-    "org.apache.kafka" % "kafka-streams" % kafkaVersion exclude(slf4jLog4jOrg, slf4jLog4jArtifact)
+    "org.apache.kafka" % "kafka-streams" % kafkaVersion
   ))
   .dependsOn(embeddedKafka)

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/ConsumerExtensions.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/ConsumerExtensions.scala
@@ -2,7 +2,6 @@ package net.manub.embeddedkafka
 
 import org.apache.kafka.clients.consumer.{ConsumerRecord, KafkaConsumer}
 import org.apache.kafka.common.KafkaException
-import org.apache.log4j.Logger
 
 import scala.util.Try
 
@@ -12,8 +11,6 @@ object ConsumerExtensions {
   case class ConsumerRetryConfig(maximumAttempts: Int = 3, poll: Long = 2000)
 
   implicit class ConsumerOps[K, V](val consumer: KafkaConsumer[K, V]) {
-
-    private val logger = Logger.getLogger(getClass)
 
     /** Consume messages from one or many topics and return them as a lazily evaluated Scala Stream.
       * Depending on how many messages are taken from the Scala Stream it will try up to retryConf.maximumAttempts times
@@ -34,7 +31,6 @@ object ConsumerExtensions {
       val attempts = 1 to retryConf.maximumAttempts
       attempts.toStream.flatMap { attempt =>
         val batch: Seq[T] = getNextBatch(retryConf.poll, topics)
-        logger.debug(s"----> Batch $attempt ($topics) | ${batch.mkString("|")}")
         batch
       }
     }

--- a/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreams.scala
+++ b/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreams.scala
@@ -2,7 +2,6 @@ package net.manub.embeddedkafka.streams
 
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig, UUIDs}
 import org.apache.kafka.streams.{KafkaStreams, Topology}
-import org.apache.log4j.Logger
 import org.scalatest.Suite
 
 /** Helper trait for testing Kafka Streams.
@@ -11,8 +10,6 @@ import org.scalatest.Suite
   */
 trait EmbeddedKafkaStreams extends EmbeddedKafka with TestStreamsConfig {
   this: Suite =>
-
-  private val logger = Logger.getLogger(classOf[EmbeddedKafkaStreams])
 
   /** Execute Kafka streams and pass a block of code that can
     * operate while the streams are active.
@@ -34,7 +31,6 @@ trait EmbeddedKafkaStreams extends EmbeddedKafka with TestStreamsConfig {
     withRunningKafka {
       topicsToCreate.foreach(topic => createCustomTopic(topic))
       val streamId = UUIDs.newUuid().toString
-      logger.debug(s"Creating stream with Application ID: [$streamId]")
       val streams =
         new KafkaStreams(topology, streamConfig(streamId, extraConfig))
       streams.start()


### PR DESCRIPTION
Why exclude `slf4j-log4j12` and moments later reimport it?

Also remove the few usages of `Logger` since they're not providing any real value.