### PR TITLE
143 Kafka should be configured to point to the launched zookeeper

### DIFF
--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedServer.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedServer.scala
@@ -51,7 +51,8 @@ private[embeddedkafka] trait EmbeddedServerWithKafka extends EmbeddedServer {
   */
 case class EmbeddedK(factory: Option[EmbeddedZ],
                      broker: KafkaServer,
-                     logsDirs: Directory)(implicit config: EmbeddedKafkaConfig)
+                     logsDirs: Directory,
+                     config: EmbeddedKafkaConfig)
     extends EmbeddedServerWithKafka {
 
   /**
@@ -72,7 +73,8 @@ case class EmbeddedK(factory: Option[EmbeddedZ],
 }
 
 object EmbeddedK {
-  def apply(broker: KafkaServer, logsDirs: Directory)(
-      implicit config: EmbeddedKafkaConfig): EmbeddedK =
-    EmbeddedK(factory = None, broker, logsDirs)
+  def apply(broker: KafkaServer,
+            logsDirs: Directory,
+            config: EmbeddedKafkaConfig): EmbeddedK =
+    EmbeddedK(factory = None, broker, logsDirs, config)
 }


### PR DESCRIPTION
instance.  Previously, if 0 was passed for both kafka and zookeeper
ports, zookeeper would start on an available port; however, kafka was
told that zookeeper was listening on port 0.

Addresses #143 

I also removed the implicit config from `EmbeddedK`.  It didn't look
like it was being used anywhere...  However, I added it as a required
argument.  This was done to allow Java code like this:

```java
int kafkaPort = 0;
int zookeeperPort = 0;

EmbeddedKafka$ kafka = EmbeddedKafka$.MODULE$;

EmbeddedKafkaConfig cfg = new EmbeddedKafkaConfigImpl(
        kafkaPort,
        zookeeperPort,
        Map$.MODULE$.empty(),
        Map$.MODULE$.empty(),
        Map$.MODULE$.empty()
);
EmbeddedK serverInfo = kafka.start(cfg);
EmbeddedKafkaConfig actualCfg = serverInfo.config();
kafka.publishStringMessageToKafka("topic", "message", actualCfg);
```