### PR TITLE
144 Remove the coupling with ScalaTest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,8 @@ lazy val commonSettings = Seq(
 
 lazy val commonLibrarySettings = libraryDependencies ++= Seq(
   "org.apache.avro" % "avro" % "1.8.1",
-  "org.scalatest" %% "scalatest" % "3.0.5",
   "org.apache.kafka" %% "kafka" % kafkaVersion,
+  "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % Test,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test
 )

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/EmbeddedKafka.scala
@@ -24,7 +24,6 @@ import org.apache.kafka.common.serialization.{
 }
 import org.apache.kafka.common.{KafkaException, TopicPartition}
 import org.apache.zookeeper.server.{ServerCnxnFactory, ZooKeeperServer}
-import org.scalatest.Suite
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
@@ -34,7 +33,6 @@ import scala.reflect.io.Directory
 import scala.util.Try
 
 trait EmbeddedKafka extends EmbeddedKafkaSupport[EmbeddedKafkaConfig] {
-  this: Suite =>
 
   override def baseConsumerConfig(
       implicit config: EmbeddedKafkaConfig): Map[String, Object] =

--- a/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreams.scala
+++ b/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreams.scala
@@ -2,14 +2,12 @@ package net.manub.embeddedkafka.streams
 
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig, UUIDs}
 import org.apache.kafka.streams.{KafkaStreams, Topology}
-import org.scalatest.Suite
 
 /** Helper trait for testing Kafka Streams.
   * It creates an embedded Kafka Instance for each test case.
   * Use `runStreams` to execute your streams.
   */
 trait EmbeddedKafkaStreams extends EmbeddedKafka with TestStreamsConfig {
-  this: Suite =>
 
   /** Execute Kafka streams and pass a block of code that can
     * operate while the streams are active.

--- a/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreamsAllInOne.scala
+++ b/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/EmbeddedKafkaStreamsAllInOne.scala
@@ -3,7 +3,6 @@ package net.manub.embeddedkafka.streams
 import net.manub.embeddedkafka.{Consumers, EmbeddedKafkaConfig}
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.streams.Topology
-import org.scalatest.Suite
 
 /** Convenience trait for testing Kafka Streams with ScalaTest.
   * It exposes `EmbeddedKafkaStreams.runStreams` as well as `Consumers` api
@@ -13,7 +12,6 @@ import org.scalatest.Suite
   * @see [[EmbeddedKafkaStreams]]
   */
 trait EmbeddedKafkaStreamsAllInOne extends EmbeddedKafkaStreams with Consumers {
-  this: Suite =>
 
   /** Run Kafka Streams while offering a String-based consumer for easy testing of stream output.
     *

--- a/schema-registry/src/main/scala/net.manub.embeddedkafka/schemaregistry/streams/EmbeddedKafkaStreamsWithSchemaRegistry.scala
+++ b/schema-registry/src/main/scala/net.manub.embeddedkafka/schemaregistry/streams/EmbeddedKafkaStreamsWithSchemaRegistry.scala
@@ -8,7 +8,6 @@ import net.manub.embeddedkafka.schemaregistry.{
 }
 import net.manub.embeddedkafka.streams.TestStreamsConfig
 import org.apache.kafka.streams.{KafkaStreams, Topology}
-import org.scalatest.Suite
 
 // TODO: need to find a better way of not duplicating this code from the kafka-streams module
 
@@ -19,7 +18,6 @@ import org.scalatest.Suite
 trait EmbeddedKafkaStreamsWithSchemaRegistry
     extends EmbeddedKafkaWithSchemaRegistry
     with TestStreamsConfig {
-  this: Suite =>
 
   /** Execute Kafka streams and pass a block of code that can
     * operate while the streams are active.

--- a/schema-registry/src/main/scala/net.manub.embeddedkafka/schemaregistry/streams/EmbeddedKafkaStreamsWithSchemaRegistryAllInOne.scala
+++ b/schema-registry/src/main/scala/net.manub.embeddedkafka/schemaregistry/streams/EmbeddedKafkaStreamsWithSchemaRegistryAllInOne.scala
@@ -4,7 +4,6 @@ import net.manub.embeddedkafka.Consumers
 import net.manub.embeddedkafka.schemaregistry.EmbeddedKafkaConfigWithSchemaRegistry
 import org.apache.kafka.clients.consumer.KafkaConsumer
 import org.apache.kafka.streams.Topology
-import org.scalatest.Suite
 
 // TODO: need to find a better way of not duplicating this code from the kafka-streams module
 
@@ -18,7 +17,6 @@ import org.scalatest.Suite
 trait EmbeddedKafkaStreamsWithSchemaRegistryAllInOne
     extends EmbeddedKafkaStreamsWithSchemaRegistry
     with Consumers {
-  this: Suite =>
 
   /** Run Kafka Streams while offering a String-based consumer for easy testing of stream output.
     *


### PR DESCRIPTION
#144 

From what I can tell, there is no need to require that ScalaTest's
`Suite` was mixed in.  Without this, this library can be used in
more contexts without dragging in scalatest classes.

This is just food for thought.  I almost never use self-types, so I
might be missing something.  However, the following appear to be true:

1. The tests of this project pass.
2. My TestNG tests that use EmbeddedKafka#start/stop work.
3. My existing Scala project that is mixing in EmbeddedKafka to
ScalaTest tests still work.