### PR TITLE
bump Confluent version to 1.1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtrelease.Version
 parallelExecution in ThisBuild := false
 
 val kafkaVersion = "1.1.1"
-val confluentVersion = "4.1.0"
+val confluentVersion = "4.1.1"
 val akkaVersion = "2.5.14"
 
 lazy val commonSettings = Seq(


### PR DESCRIPTION
[Release notes](https://docs.confluent.io/4.1.1/release-notes.html#cp-4-1-1-release-notes).