### PR TITLE
Updated kafka to 2.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@ import sbtrelease.Version
 
 parallelExecution in ThisBuild := false
 
-val kafkaVersion = "2.0.0"
-val confluentVersion = "5.0.0"
+val kafkaVersion = "2.1.0"
+val confluentVersion = "5.1.0"
 val akkaVersion = "2.5.14"
 
 lazy val commonSettings = Seq(

--- a/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/TestStreamsConfig.scala
+++ b/kafka-streams/src/main/scala/net/manub/embeddedkafka/streams/TestStreamsConfig.scala
@@ -1,6 +1,7 @@
 package net.manub.embeddedkafka.streams
 
 import java.nio.file.Files
+import java.util.Properties
 
 import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.consumer.{ConsumerConfig, OffsetResetStrategy}
@@ -19,7 +20,7 @@ trait TestStreamsConfig {
     */
   def streamConfig(streamName: String,
                    extraConfig: Map[String, AnyRef] = Map.empty)(
-      implicit kafkaConfig: EmbeddedKafkaConfig): StreamsConfig = {
+      implicit kafkaConfig: EmbeddedKafkaConfig): Properties = {
     import scala.collection.JavaConverters._
 
     val defaultConfig = Map(
@@ -33,6 +34,9 @@ trait TestStreamsConfig {
     )
     val configOverwrittenByExtra = defaultConfig ++
       extraConfig
-    new StreamsConfig(configOverwrittenByExtra.asJava)
+
+    val props = new Properties()
+    props.putAll(configOverwrittenByExtra.asJava)
+    props
   }
 }


### PR DESCRIPTION
Fixed a deprecation warning in EmbeddedKafkaStreams caused by the upgrade.