### PR TITLE
[bump] dependencies in preparation for scala 2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ atlassian-ide-plugin.xml
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
+
+
+.bloop
+.metals

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: scala
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 scala:
   - 2.11.12
-  - 2.12.6
+  - 2.12.9
 
 sudo: false
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,14 +2,14 @@ import sbtrelease.Version
 
 parallelExecution in ThisBuild := false
 
-val kafkaVersion = "2.0.0"
-val confluentVersion = "5.0.0"
-val akkaVersion = "2.5.14"
+val kafkaVersion = "2.3.0"
+val confluentVersion = "5.3.0"
+val akkaVersion = "2.5.25"
 
 lazy val commonSettings = Seq(
   organization := "net.manub",
-  scalaVersion := "2.12.6",
-  crossScalaVersions := Seq("2.12.6", "2.11.12"),
+  scalaVersion := "2.12.9",
+  crossScalaVersions := Seq("2.12.9", "2.11.12"),
   homepage := Some(url("https://github.com/manub/scalatest-embedded-kafka")),
   parallelExecution in Test := false,
   logBuffered in Test := false,
@@ -20,10 +20,10 @@ lazy val commonSettings = Seq(
 )
 
 lazy val commonLibrarySettings = libraryDependencies ++= Seq(
-  "org.apache.avro" % "avro" % "1.8.2",
+  "org.apache.avro" % "avro" % "1.9.1",
   "org.apache.kafka" %% "kafka" % kafkaVersion,
   "org.slf4j" % "slf4j-log4j12" % "1.7.25" % Test,
-  "org.scalatest" %% "scalatest" % "3.0.5" % Test,
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test,
   "com.typesafe.akka" %% "akka-actor" % akkaVersion % Test,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % Test
 )

--- a/embedded-kafka/src/main/scala/net/manub/embeddedkafka/avro/avroMarshallers.scala
+++ b/embedded-kafka/src/main/scala/net/manub/embeddedkafka/avro/avroMarshallers.scala
@@ -13,9 +13,7 @@ import org.apache.avro.specific.{
 import org.apache.kafka.common.serialization.{Deserializer, Serializer}
 
 class KafkaAvroDeserializer[T <: SpecificRecord](schema: Schema)
-    extends Deserializer[T]
-    with NoOpConfiguration
-    with NoOpClose {
+    extends Deserializer[T] {
 
   private val reader = new SpecificDatumReader[T](schema)
 
@@ -25,10 +23,7 @@ class KafkaAvroDeserializer[T <: SpecificRecord](schema: Schema)
   }
 }
 
-class KafkaAvroSerializer[T <: SpecificRecord]()
-    extends Serializer[T]
-    with NoOpConfiguration
-    with NoOpClose {
+class KafkaAvroSerializer[T <: SpecificRecord]() extends Serializer[T] {
 
   private def toBytes(nullableData: T): Array[Byte] =
     Option(nullableData).fold[Array[Byte]](null) { data =>

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.8


### PR DESCRIPTION
I couldn't add the 2.13 target because kafka itself has no binary
yet. I figured this out later when I already upgraded the other
dependencies. Maybe this is still useful to have.